### PR TITLE
Fixed "multiply defined symbols" linker error.

### DIFF
--- a/src/Subwindow.ipp
+++ b/src/Subwindow.ipp
@@ -111,12 +111,12 @@ inline void Subwindow::syncdown()
 	wsyncdown(win_);
 }
 
-void Subwindow::assign(WINDOW*)
+inline void Subwindow::assign(WINDOW*)
 {
 	assert(false && "Can't call nccpp::Subwindow::assign");
 }
 
-void Subwindow::destroy()
+inline void Subwindow::destroy()
 {
 	assert(false && "Can't call nccpp::Subwindow::destroy");
 }


### PR DESCRIPTION
Declared Subwindow::assign() and Subwindow::destroy() as inline to fix "multiply defined symbols" linker error.