### PR TITLE
Create CMake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,37 +42,41 @@ file(GLOB_RECURSE source_inline src/*.ipp)
 
 install(FILES ${headers} ${source_inline} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/ncursescpp/)
 
+find_package(Curses REQUIRED)
+
 add_library(ncursescpp INTERFACE)
 set_target_properties (ncursescpp PROPERTIES EXPORT_NAME ncursescpp)
 target_include_directories(ncursescpp INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
 )
+set_target_properties(ncursescpp PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${CURSES_INCLUDE_DIRS}"
+  INTERFACE_LINK_LIBRARIES "${CURSES_LIBRARIES}"
+)
 
 include (CMakePackageConfigHelpers)
 set(config_install_dir "share/cmake/${PROJECT_NAME}/")
 configure_package_config_file (
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ncursescppConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/ncursescppConfig.cmake
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ncursescpp-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/ncursescpp-config.cmake
   INSTALL_DESTINATION ${config_install_dir}
   NO_CHECK_REQUIRED_COMPONENTS_MACRO
 )
-export (TARGETS ncursescpp NAMESPACE Ncursescpp:: FILE ncursescppTargets.cmake)
+export (TARGETS ncursescpp NAMESPACE ncursescpp:: FILE ncursescpp-targets.cmake)
 
 install(
   FILES 
-    ${CMAKE_CURRENT_BINARY_DIR}/ncursescppConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/ncursescpp-config.cmake
   DESTINATION ${config_install_dir}
 )
-install (TARGETS ncursescpp EXPORT ncursescppTargets)
-install(EXPORT ncursescppTargets
+install (TARGETS ncursescpp EXPORT ncursescpp-targets)
+install(EXPORT ncursescpp-targets
   FILE
-    ncursescppTargets.cmake
+    ncursescpp-targets.cmake
   NAMESPACE
-    Ncursescpp::
+    ncursescpp::
   DESTINATION
     ${config_install_dir}
 )
-
-
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
  # knowledge of the CeCILL-B license and that you accept its terms.
  #####
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(ncursescpp)
 
@@ -41,3 +41,38 @@ file(GLOB_RECURSE headers src/*.hpp)
 file(GLOB_RECURSE source_inline src/*.ipp)
 
 install(FILES ${headers} ${source_inline} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/ncursescpp/)
+
+add_library(ncursescpp INTERFACE)
+set_target_properties (ncursescpp PROPERTIES EXPORT_NAME ncursescpp)
+target_include_directories(ncursescpp INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${INCLUDE_INSTALL_DIR}>
+)
+
+include (CMakePackageConfigHelpers)
+set(config_install_dir "share/cmake/${PROJECT_NAME}/")
+configure_package_config_file (
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ncursescppConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/ncursescppConfig.cmake
+  INSTALL_DESTINATION ${config_install_dir}
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+export (TARGETS ncursescpp NAMESPACE Ncursescpp:: FILE ncursescppTargets.cmake)
+
+install(
+  FILES 
+    ${CMAKE_CURRENT_BINARY_DIR}/ncursescppConfig.cmake
+  DESTINATION ${config_install_dir}
+)
+install (TARGETS ncursescpp EXPORT ncursescppTargets)
+install(EXPORT ncursescppTargets
+  FILE
+    ncursescppTargets.cmake
+  NAMESPACE
+    Ncursescpp::
+  DESTINATION
+    ${config_install_dir}
+)
+
+
+

--- a/README.md
+++ b/README.md
@@ -20,10 +20,18 @@ Ncursescpp goal is to provide access to ncurses through an interface using C++ r
 
 Ncursescpp is a header-only library. You can use [CMake](http://www.cmake.org) to install, or copy the library files where you want. Using ncursescpp in a program requires a compiler supporting the C++11 standard.
 
+A CMake target is also created. Use Ncursescpp in your `CMakeLists.txt` like so:
+```cmake
+find_package(ncursescpp REQUIRED)
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC ncursescpp::ncursescpp
+)
+```
+
 ## License
 
 Ncursescpp is distributed under the CeCILL-B license (akin to the MIT license). See the LICENSE file or http://www.cecill.info/index.en.html for more information.
 
-## Documentation
+## Documentation
 
 You can generate the library documentation with [Doxygen](http://www.doxygen.org/index.html). Go to the `doc/` directory and run `doxygen Doxyfile`. The documentation only contains information about ncursescpp interface, as ncurses is already fully documented.

--- a/cmake/ncursescpp-config.cmake.in
+++ b/cmake/ncursescpp-config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+find_package(Curses REQUIRED)
+
+include ("${CMAKE_CURRENT_LIST_DIR}/ncursescpp-targets.cmake")
+set(ncursescpp_FOUND)
+

--- a/cmake/ncursescppConfig.cmake.in
+++ b/cmake/ncursescppConfig.cmake.in
@@ -1,4 +1,0 @@
-@PACKAGE_INIT@
-include ("${CMAKE_CURRENT_LIST_DIR}/ncursescppTargets.cmake")
-set(ncursescpp_FOUND)
-

--- a/cmake/ncursescppConfig.cmake.in
+++ b/cmake/ncursescppConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+include ("${CMAKE_CURRENT_LIST_DIR}/ncursescppTargets.cmake")
+set(ncursescpp_FOUND)
+


### PR DESCRIPTION
Added CMake code in order to create a proper CMake target and make it easy for people to include Ncursescpp "the CMake way".

Unfortunately, this requires quite a bit of bloat in CMakeLists.txt, but the gain is that it is super easy to use Ncursescpp in new projects. The README has been updated accordingly.

Changes include:
- Add CMake target
- Use namespace for that target
- `find_package(Curses)` to ensure that dependencies exist    
  (may be installed with `sudo apt install -y libncurses-dev`)
- Update README.
- Increase CMake minimum required version to 3.0